### PR TITLE
fix: use a compile time constant value instead of SIGSTKSZ on platforms with recent glibc

### DIFF
--- a/ctrlppcheck/cli/cppcheckexecutor.cpp
+++ b/ctrlppcheck/cli/cppcheckexecutor.cpp
@@ -288,7 +288,13 @@ static void print_stacktrace(FILE* output, bool demangling, int maxdepth, bool l
 #endif
 }
 
-static const size_t MYSTACKSIZE = 16*1024+SIGSTKSZ; // wild guess about a reasonable buffer
+#if defined(__USE_DYNAMIC_STACK_SIZE) && __USE_DYNAMIC_STACK_SIZE
+    // on glibc >= 2.34 SIGSTKSZ is not longer constant
+    // fall back to 8192 as the value used in some Linux distributions
+    static constexpr size_t MYSTACKSIZE = 16*1024+8192; // wild guess about a reasonable buffer
+#else
+    static constexpr size_t MYSTACKSIZE = 16*1024+SIGSTKSZ; // wild guess about a reasonable buffer
+#endif
 static char mytstack[MYSTACKSIZE]= {0}; // alternative stack for signal handler
 static bool bStackBelowHeap=false; // lame attempt to locate heap vs. stack address space. See CppCheckExecutor::check_wrapper()
 


### PR DESCRIPTION
Since glibc 2.34, SIGSTKSZ is no longer (necessarily) compile-time constant. This is indicated by `__USE_DYNAMIC_STACK_SIZE` being set. On these platforms, we currently assume a default stack size of 8192. This value was taken from the includes shipped with Ubuntu 20.04.

Fixes siemens/CtrlppCheck#26