### PR TITLE
Add option -formatCtrlCode to allow automatic formatting of ctrl code

### DIFF
--- a/WinCC_OA_Test/Projects/TfCustomizedQG/scripts/astyle.ctl
+++ b/WinCC_OA_Test/Projects/TfCustomizedQG/scripts/astyle.ctl
@@ -2,7 +2,8 @@
 //--------------------------------------------------------------------------------
 /**
   @file $relPath
-  @copyright $copyright
+  @copyright Copyright 2022 SIEMENS AG
+             SPDX-License-Identifier: GPL-3.0-only
   @author mPokorny
 */
 

--- a/WinCC_OA_Test/Projects/TfCustomizedQG/scripts/astyle.ctl
+++ b/WinCC_OA_Test/Projects/TfCustomizedQG/scripts/astyle.ctl
@@ -1,0 +1,54 @@
+// $License: NOLICENSE
+//--------------------------------------------------------------------------------
+/**
+  @file $relPath
+  @copyright $copyright
+  @author mPokorny
+*/
+
+//--------------------------------------------------------------------------------
+// Libraries used (#uses)
+
+//--------------------------------------------------------------------------------
+// Variables and Constants
+
+//--------------------------------------------------------------------------------
+/**
+*/
+main(string sourcePath)
+{
+  dyn_string args;
+
+  args[1] = getPath(BIN_REL_PATH, _WIN32 ? "astyle.exe" : "astyle");
+  args[2] = "--options=" + makeNativePath(getPath(CONFIG_REL_PATH, "astyle.config"));
+
+  dyn_string files = getFileNamesRecursive(sourcePath, "*.ctl");
+  dyn_string filesToCheck;
+
+  for (int i = 1; i <= dynlen(files); i++)
+  {
+    const string path = makeUnixPath(files[i]);
+
+    if (path.contains("suite_CtrlppCheck") && path.contains("testScripts"))
+      continue; // here are located ctrlppcheck test-scripts. Formatting will destroy bad cases
+
+    dynAppend(filesToCheck, makeNativePath(path));
+  }
+
+  dynAppend(args, filesToCheck);
+
+  string stdErr, stdOut;
+
+  DebugTN("Start", args);
+  int rc = system(args, stdOut, stdErr);
+
+  strreplace(stdOut, "\r", "");
+  DebugTN("fine", rc, stdErr, strsplit(stdOut, "\n"));
+
+  // remove the backups
+  for (int i = 1; i <= dynlen(files); i++)
+  {
+    if (isfile(files[i] + ".orig"))
+      remove(files[i] + ".orig");
+  }
+}

--- a/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/FileSys/QgDir.ctl
+++ b/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/FileSys/QgDir.ctl
@@ -20,30 +20,30 @@ class TstDir : OaTest
 
   protected int startTestCase(const string tcId)
   {
-    switch( tcId )
+    switch (tcId)
     {
       case "QgDir":
       {
         QgDir dir = QgDir();
         QgDir dir2 = QgDir("non existing/ path");
-        
+
         assertEqual(dir.getDirPath(), "");
         assertEqual(dir2.getDirPath(), makeNativePath("non existing/ path"));
-        
-        assertFalse(dir.exists());        
+
+        assertFalse(dir.exists());
         assertFalse(dir2.exists());
-        
+
         dir.setDirPath(PROJ_PATH);
         assertEqual(dir.getDirPath(), makeNativePath(PROJ_PATH));
         assertTrue(dir.exists());
-        
+
         dir.setDirPath(PROJ_PATH + createUuid());
         assertFalse(dir.exists());
         assertEqual(dir.mk(), 0);
         assertTrue(dir.exists());
         assertEqual(dir.mk(), 0);
         assertTrue(dir.exists());
-        assertEqual(dir.rm(), 0);     
+        assertEqual(dir.rm(), 0);
         assertFalse(dir.exists());
 
         string dirPath = dir.getDirPath();
@@ -53,8 +53,8 @@ class TstDir : OaTest
         assertTrue(dir.exists());
         assertEqual(dir.rm(), 0);
         assertFalse(dir.exists());
-        
-        
+
+
         dir.setDirPath(dirPath);
         assertTrue(dir.exists());
         assertEqual(dir.rm(), 0);
@@ -62,10 +62,10 @@ class TstDir : OaTest
 
         assertEqual(dir.rm(), -1);
         assertEqual(dir2.rm(), -1);
-                
+
         dir.setDirPath("");
         assertEqual(dir.rm(), -1);
-        
+
         return 0;
       }
     }

--- a/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/Math/Math.ctl
+++ b/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/Math/Math.ctl
@@ -23,7 +23,7 @@ class TstMath : OaTest
 
   protected int startTestCase(const string tcId)
   {
-    switch( tcId )
+    switch (tcId)
     {
       case "Math::getPercent()":
       {

--- a/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/QualityGates/Qg.ctl
+++ b/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/QualityGates/Qg.ctl
@@ -23,13 +23,13 @@ class TstQg : OaTest
 
   protected int startTestCase(const string tcId)
   {
-    switch( tcId )
+    switch (tcId)
     {
       case "Qg::get/setId()":
       {
         assertEqual(Qg::getId(), "");
         Qg::setId("some one ID");
-        assertEqual(Qg::getId(), "some one ID");        
+        assertEqual(Qg::getId(), "some one ID");
         return 0;
       }
     }

--- a/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/Variables/Float.ctl
+++ b/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/classes/Variables/Float.ctl
@@ -1,5 +1,5 @@
 /*!
- * @brief Tests for class: Float 
+ * @brief Tests for class: Float
  *
  * @author lschopp
  */
@@ -15,7 +15,7 @@
 //--------------------------------------------------------------------------------
 class TstFloat : OaTest
 {
-  
+
   public dyn_string getAllTestCaseIds()
   {
     // list with our testcases
@@ -24,7 +24,7 @@ class TstFloat : OaTest
 
   protected int startTestCase(const string tcId)
   {
-    switch( tcId )
+    switch (tcId)
     {
       case "Float":
       {
@@ -32,28 +32,28 @@ class TstFloat : OaTest
         f1 = 100;
         f2 = 33;
         Float f = Float(f1 / f2);
-  
+
         assertEqual((string)f.round(), "3.03");
         assertEqual((string)f.round(4), "3.0303");
         assertEqual((string)f.round(0), "3");
-  
+
         f.set(f2 / f1);
         assertEqual((string)f.round(), "0.33");
-  
+
         f.set(0);
         assertEqual((string)f.round(), "0");
-  
+
         f.set(1.4356);
         assertEqual((string)f.round(), "1.44");
         assertEqual(f.get(), 1.4356);
-        
+
         f.set(1.4323);
         assertEqual((string)f.round(), "1.43");
         assertEqual(f.get(), 1.4323);
-                
+
         f.set(1.4323);
         assertEqual((string)f.round(-1), "1");
-        
+
         return 0;
       }
     }

--- a/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/fileSys.ctl
+++ b/WinCC_OA_Test/TestSuites/suite_Common/sub_unit/scripts/tests/libs/fileSys.ctl
@@ -11,7 +11,7 @@
 
 //--------------------------------------------------------------------------------
 class TstFileSys : OaTest
-{  
+{
   public dyn_string getAllTestCaseIds()
   {
     // list with our testcases
@@ -20,7 +20,7 @@ class TstFileSys : OaTest
 
   protected int startTestCase(const string tcId)
   {
-    switch( tcId )
+    switch (tcId)
     {
       case "fileSys getFileNamesRecursive":
       {

--- a/WinCC_OA_Test/TestSuites/suite_CtrlppCheck/sub_app/scripts/QgCtrlppcheckTests.ctl
+++ b/WinCC_OA_Test/TestSuites/suite_CtrlppCheck/sub_app/scripts/QgCtrlppcheckTests.ctl
@@ -26,7 +26,8 @@ class MockCppCheck : CppCheck
     s = substr(s, 0, strpos(s, "\n")); // get fist lines
     const string key = "// start options: ";
     int idx = strpos(s, key);
-    if ( idx >= 0 )
+
+    if (idx >= 0)
       s = " " + substr(s, idx + strlen(key));
     else
       s = "";
@@ -51,6 +52,7 @@ class MockCppCheck : CppCheck
       oaUnitAbort(tcId, "Reference file " + refFile + " is empty");
       return;
     }
+
     reference.strToErrList(str);
 
 //     if ( dynlen(errList) != dynlen(reference.errList) )
@@ -60,26 +62,30 @@ class MockCppCheck : CppCheck
 //     }
 
     dyn_string simpleErrStrings;
-    for(int i = 1; i <= dynlen(reference.errList); i++)
+
+    for (int i = 1; i <= dynlen(reference.errList); i++)
     {
       reference.errList[i].path = "";
     }
-    for(int i = 1; i <= dynlen(errList); i++)
+
+    for (int i = 1; i <= dynlen(errList); i++)
     {
       errList[i].path = "";
       dynAppend(simpleErrStrings, errList[i].toStdErrString());
     }
 
 
-    for(int i = 1; i <= dynlen(reference.errList); i++)
+    for (int i = 1; i <= dynlen(reference.errList); i++)
     {
       CppCheckError expErr = reference.errList[i];
       string expErrorStr = expErr.toStdErrString();
       mapping map = makeMapping("ErrMsg", "Ctrlppcheck can not found this error:" +
-                                          "\n  File:\n" + refFile +
-                                          "\n  ExpectedValue:\n" + expErrorStr);
-      if ( expErr.knownBug != "" )
+                                "\n  File:\n" + refFile +
+                                "\n  ExpectedValue:\n" + expErrorStr);
+
+      if (expErr.knownBug != "")
         map["KnownBug"] = expErr.knownBug;
+
       // DebugN(__FUNCTION__, map, expErr);
       oaUnitAssertGreater(tcId, dynContains(simpleErrStrings, expErrorStr), 0, map);
     }
@@ -100,15 +106,17 @@ class TstCtrlppcheck : OaTest
 
   protected int startTestCase(const string tcId)
   {
-    switch( tcId )
+    switch (tcId)
     {
       case "Ctrlppcheck":
       {
         const string path = getPath(SCRIPTS_REL_PATH, "testScripts/" + testScriptPath);
+
         if (path.isEmpty())
         {
           return abort("Test script does not exists: " + SCRIPTS_REL_PATH + "testScripts/" + testScriptPath);
         }
+
         this.info("check file: " + path);
 
         string refFile = testScriptPath;
@@ -126,7 +134,7 @@ class TstCtrlppcheck : OaTest
 
         check.settings.enableLibCheck = FALSE;
         // check.settings.enableHeadersCheck = TRUE;
-        check.settings.includeSubProjects = TRUE; 	
+        check.settings.includeSubProjects = TRUE;
         check.settings.inconclusive = FALSE;
         check.settings.verbose = FALSE;
         check.settings.inlineSuppressions = FALSE;
@@ -150,7 +158,8 @@ class TstCtrlppcheck : OaTest
 
         // make a copy for futher analysis
         string resDir = PROJ_PATH + LOG_REL_PATH + "ctrlPpCheck/";
-        if ( !isdir(resDir) )
+
+        if (!isdir(resDir))
           mkdir(resDir);
 
         moveFile(PROJ_PATH + LOG_REL_PATH + "cppcheck-result.xml",  resDir + baseName(refFile));

--- a/WinCC_OA_Test/TestSuites/suite_QgPicturesCheck/sub_unit/scripts/tests/libs/classes/QualityGates/QgStaticCheck/Pictures/PicturesDir.ctl
+++ b/WinCC_OA_Test/TestSuites/suite_QgPicturesCheck/sub_unit/scripts/tests/libs/classes/QualityGates/QgStaticCheck/Pictures/PicturesDir.ctl
@@ -27,8 +27,8 @@ class TstQg : OaTest
   //------------------------------------------------------------------------------
   public int setUp()
   {
-    if ( OaTest::setUp() )
-     return -1;
+    if (OaTest::setUp())
+      return -1;
 
     // eliminate false positives
     QgVersionResult::enableOaTestCheck = false;
@@ -38,7 +38,7 @@ class TstQg : OaTest
   //------------------------------------------------------------------------------
   protected int startTestCase(const string tcId)
   {
-    switch( tcId )
+    switch (tcId)
     {
       case "PicturesDir::ctor":
       {
@@ -46,15 +46,15 @@ class TstQg : OaTest
         assertEqual(dir.getName(), "");
         assertEqual(dir.getCountOfFiles(), 0);
         assertEqual(dir.getCountOfSubDirs(), 0);
-        
+
         dir.setDir(PROJ_PATH);
         assertEqual(dir.getName(), PROJ);
         assertEqual(dir.getCountOfFiles(), 0);
         assertEqual(dir.getCountOfSubDirs(), 0);
-        
+
         return 0;
       }
-      
+
       case "PicturesDir::exists":
       {
         PicturesDir dir = PicturesDir();
@@ -65,65 +65,65 @@ class TstQg : OaTest
         assertFalse(dir.exists());
         return 0;
       }
-      
+
       case "PicturesDir::calculate":
       {
         PicturesDir dir = PicturesDir();
         string tmpDir = _makeTmpDir();
-        
+
         // not existing
         assertEqual(dir.calculate(), -1);
         assertEqual(dir.getCountOfFiles(), 0);
         assertEqual(dir.getCountOfFilesRecursive(), 0);
         assertEqual(dir.getCountOfSubDirs(), 0);
-        
+
         // existing, but empty
         dir.setDir(tmpDir);
-        
+
         assertEqual(dir.calculate(), 0);
         assertEqual(dir.getCountOfFiles(), 0);
         assertEqual(dir.getCountOfFilesRecursive(), 0);
         assertEqual(dir.getCountOfSubDirs(), 0);
-        
+
         // existing with 2 sub dirs and 1 file
         mkdir(tmpDir + "subDir1");
         mkdir(tmpDir + "subDir2");
         fclose(fopen(tmpDir + "file.png", "wb+"));
-        
+
         assertEqual(dir.calculate(), 0);
         assertEqual(dir.getCountOfFiles(), 1);
         assertEqual(dir.getCountOfFilesRecursive(), 1);
         assertEqual(dir.getCountOfSubDirs(), 2);
-        
-        
+
+
         // existing witth 3 files in defirent sub dirs
         fclose(fopen(tmpDir + "subDir1/file.PNG", "wb+"));
         fclose(fopen(tmpDir + "subDir1/file.txt", "wb+"));
-        
+
         assertEqual(dir.calculate(), 0);
         assertEqual(dir.getCountOfFiles(), 1);
         assertEqual(dir.getCountOfFilesRecursive(), 3);
         assertEqual(dir.getCountOfSubDirs(), 2);
-        
+
         dyn_anytype childs = dir.getSubDirs();
-        assertEqual(dynlen(childs), 2); 
+        assertEqual(dynlen(childs), 2);
         assertEqual(childs[1].getName(), "subDir1");
-        
-        
+
+
         dir.setDir(PROJ_PATH);
         assertTrue(dir.exists());
         dir.setDir(PROJ_PATH + "abc");
         assertFalse(dir.exists());
-        
+
         rmdir(tmpDir, TRUE);
         return 0;
       }
-      
+
       case "PicturesDir::validate":
       {
         PicturesDir dir = PicturesDir();
         string tmpDir = _makeTmpDir();
-        
+
         dir.setDir(tmpDir);
 
         // check empty
@@ -133,7 +133,7 @@ class TstQg : OaTest
         assertEqual(dir.result.totalPoints, 1);
         assertEqual(QgVersionResult::lastErr, "reason.dir.isEmpty");
 //         return ;
-        
+
         // check with 10 files, try it with different extentions
         fclose(fopen(tmpDir + "file1.png", "wb+"));
         fclose(fopen(tmpDir + "file2.PNG", "wb+"));
@@ -146,16 +146,16 @@ class TstQg : OaTest
         fclose(fopen(tmpDir + "file9.png", "wb+"));
         fclose(fopen(tmpDir + "file10.png", "wb+"));
         dir.calculate();
-        
+
         assertEqual(dir.validate(), 0);
         assertEqual(dir.result.errorPoints, 0);
         assertEqual(dir.result.totalPoints, 23);
         assertEqual(dir.getCountOfFiles(), 10);
-        
+
         // to mutch files
         fclose(fopen(tmpDir + "file11.png", "wb+"));
         dir.calculate();
-        
+
         assertEqual(dir.validate(), 0);
         assertEqual(dir.result.errorPoints, 1);
         assertEqual(dir.result.totalPoints, 25);
@@ -163,7 +163,7 @@ class TstQg : OaTest
         assertEqual(dir.getCountOfFiles(), 11);
 //         DebugN(dir.result.children);
         remove(tmpDir + "file11.png");
-        
+
         // try with 5 sub dirs
         mkdir(tmpDir + "subDir1");
         fclose(fopen(tmpDir + "subDir1/file1.png", "wb+"));
@@ -176,22 +176,22 @@ class TstQg : OaTest
         mkdir(tmpDir + "subDir5");
         fclose(fopen(tmpDir + "subDir5/file1.png", "wb+"));
         dir.calculate();
-        
+
         assertEqual(dir.validate(), 0);
         assertEqual(dir.result.errorPoints, 0);
         assertEqual(dir.result.totalPoints, 48);
-        
+
         // to mutch sub dirs
         mkdir(tmpDir + "subDir6");
         fclose(fopen(tmpDir + "subDir6/file1.png", "wb+"));
         dir.calculate();
-        
+
         assertEqual(dir.validate(), 0);
         assertEqual(dir.result.errorPoints, 1);
         assertEqual(QgVersionResult::lastErr, "reason.dir.subDirCount");
 //         DebugN(dir);
         rmdir(tmpDir + "subDir6", TRUE);
-        
+
         // invalid extention, is a indirect test fi pictureFile. So it is tested that file errors are added
         fclose(fopen(tmpDir + "subDir5/file1.txt", "wb+"));
         dir.calculate();
@@ -200,7 +200,7 @@ class TstQg : OaTest
         assertEqual(dir.result.errorPoints, 1);
         assertEqual(QgVersionResult::lastErr, "reason.file.extention");
 //         DebugN(dir);
-        
+
         // claen up after test
 //         rmdir(tmpDir, TRUE);
         return 0;
@@ -209,18 +209,18 @@ class TstQg : OaTest
 
     return -1;
   }
-  
+
   //------------------------------------------------------------------------------
   string _makeTmpDir()
-  {    
+  {
     string tmpDir = dirName(tmpnam()) + "QgPictureDir/";
 
     // create tmp-dir for this test
-    if ( isdir(tmpDir) )
+    if (isdir(tmpDir))
       rmdir(tmpDir, TRUE);
-        
+
     mkdir(tmpDir);
-    
+
     return tmpDir;
   }
 };

--- a/WinCC_OA_Test/executeTests.cmd
+++ b/WinCC_OA_Test/executeTests.cmd
@@ -10,6 +10,7 @@ SET WINCC_OA_INSTALL_PATH=C:\Siemens\Automation\WinCC_OA\
 SET WINCC_OA_VERSION=3.20
 set WINCC_OA_TEST_PATH=%cd%\
 set WINCC_OA_TEST_RUN_ID=Regression-tests
+set FORMAT_CTRL_CODE=false
 
 REM get input params
 :loopStdIn
@@ -30,6 +31,11 @@ IF NOT "%1"=="" (
   )
   IF "%1"=="-OaTestRunId" (
     SET WINCC_OA_TEST_RUN_ID=%2
+    SHIFT
+  )
+
+  IF "%1"=="-formatCtrlCode" (
+    SET FORMAT_CTRL_CODE=true
     SHIFT
   )
 
@@ -78,6 +84,13 @@ IF %ERRORLEVEL% NEQ 0 IF %ERRORLEVEL% NEQ 3 (
   REM ERRORLEVEL == 3 - re-registration
   echo ERRORLEVEL: %ERRORLEVEL%
   exit 0
+)
+
+REM --------------------------------------------------------------------------
+REM Format ctrl code
+if %FORMAT_CTRL_CODE% == true (
+  call %oaBinPath%WCCOActrl.exe -config %WINCC_OA_TEST_PATH%Projects\TfCustomizedQG\config\config -n astyle.ctl %WINCC_OA_TEST_PATH% -log +stderr -lang en_US.utf8
+  call %oaBinPath%WCCOActrl.exe -config %WINCC_OA_TEST_PATH%Projects\TfCustomizedQG\config\config -n astyle.ctl %WINCC_OA_TEST_PATH%..\WinCCOA_QualityChecks -log +stderr -lang en_US.utf8
 )
 
 REM ---------------------------------------------------------------------------

--- a/WinCC_OA_Test/readme.md
+++ b/WinCC_OA_Test/readme.md
@@ -19,7 +19,7 @@ Following options are possible:
 -OaInstallPath ,define the installation path of WinCC OA (default C:\Siemens\Automation\WinCC_OA\)
 -OaTestPath ,define the test path (default *thisWorkspace*\WinCC_OA_Test\)
 -OaTestRunId , defines test-run ID to be executed (default Regression-tests)
--formatCtrlCode, allow automatic formatting of ctrl code - inclusive ctrl tests (default disabled)
+-formatCtrlCode, allows auto-formatting of all ctrl code - including ctrl tests (default disabled)
 
 ``` bat
 executeTests.cmd -OaVersion 3.19 -OaInstallPath C:\Siemens\Automation\WinCC_OA\ -OaTestPath C:\ws\Siemens\CtrlppCheck\WinCC_OA_Test\ -OaTestRunId Regression-tests

--- a/WinCC_OA_Test/readme.md
+++ b/WinCC_OA_Test/readme.md
@@ -18,7 +18,8 @@ Following options are possible:
 -OaVersion ,defines the WinCC OA Version (default 3.20)
 -OaInstallPath ,define the installation path of WinCC OA (default C:\Siemens\Automation\WinCC_OA\)
 -OaTestPath ,define the test path (default *thisWorkspace*\WinCC_OA_Test\)
--OaTestRunId , defines test-run ID to be executed (default Regression-tests )
+-OaTestRunId , defines test-run ID to be executed (default Regression-tests)
+-formatCtrlCode, allow automatic formatting of ctrl code - inclusive ctrl tests (default disabled)
 
 ``` bat
 executeTests.cmd -OaVersion 3.19 -OaInstallPath C:\Siemens\Automation\WinCC_OA\ -OaTestPath C:\ws\Siemens\CtrlppCheck\WinCC_OA_Test\ -OaTestRunId Regression-tests


### PR DESCRIPTION
# Request for a change on public repository on [CtrlppCheck](https://github.com/siemens/CtrlppCheck)

## Basic information
This changes allow to automatic formatting of ctrl code (inclusive tests) to use one unify style quide.

To update copyright use option ```-changeCopyright``` like

```sh
cd WinCC_OA_Test
executeTests.cmd -changeCopyright
```


## Technical information


### Testing done

Also after formatting there is no failure

![image](https://github.com/siemens/CtrlppCheck/assets/89339813/5836eca1-1df8-44e1-8805-e3dfd0dede52)


### Proposed upgrade guidelines

N/A

### Localizations

N/N

### Submitter checklist

~~- [ ] The Github issue, if it exists, is well-described.~~
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
~~- [ ] There is automated testing or an explanation that explains why this change has no tests.~~
~~- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
~~- [ ] Any localizations are transferred to /msg/ files.~~
- [x] Automated tests has been executed and valid
- [x] Changes in the interface are documented.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] C++ and Control(++) code changes are tested by automated test.
- [ ] WinCC OA guidelines for C++ and Control(++) coding have been met.
- [ ] Result of pipeline build proving error/warning free code.
- [ ] Result of automatic tests proving regression free.

<!-- TBD, maybe done in GitHub rules
- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](...).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](...)).
-->
