### PR TITLE
Cannot open reports in ctrl-editor

### DIFF
--- a/WinCCOA_QualityChecks/panels/vision/QualityChecks/QG_History.pnl
+++ b/WinCCOA_QualityChecks/panels/vision/QualityChecks/QG_History.pnl
@@ -85,7 +85,7 @@ LANG:10001 0
 1 -1.3563330008895e-14 0 E E E 1 E 1 E N "DavyGrey" E N "Isabelline" E E
  E "main(int row, string column)
 {
-  string fileName = this.cellValueRC(row, \"_resDir\") + \"QgTestVersion\\\\_Results\";
+  string fileName = this.cellValueRC(row, \"_resDir\") + \"QgTestVersion/_Results\";
   ChildPanelOnCentralModal(\"vision/QualityChecks/QG_Result.pnl\", getCatStr(\"QG_Names\",_qgId), makeDynString(\"$fileName:\" + fileName));
 }
 " 0

--- a/WinCCOA_QualityChecks/panels/vision/QualityChecks/QG_History.pnl
+++ b/WinCCOA_QualityChecks/panels/vision/QualityChecks/QG_History.pnl
@@ -1,7 +1,7 @@
 V 14
 2
-LANG:10000 0 
 LANG:10001 0 
+LANG:10000 0 
 PANEL,-1 -1 409 557 N "_3DFace" 1
 "$QgId"
 "main()
@@ -68,24 +68,24 @@ string readSummary(const string &histDirPath)
 }
 
 " 0
- 3
+ 4
 "CBRef" "1"
 "EClose" E
 "dpi" "96"
+"pdpi" "96"
 2 1 0 0 0 0 0
 ""
 DISPLAY_LAYER, 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0
 LAYER, 0 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 25 1
 "table"
 ""
-1 -1.3563330008895e-014 0 E E E 1 E 1 E N "DavyGrey" E N "Isabelline" E E
+1 -1.3563330008895e-14 0 E E E 1 E 1 E N "DavyGrey" E N "Isabelline" E E
  E "main(int row, string column)
 {
-  string fileName = this.cellValueRC(row, \"_resDir\") + \"Result\";
+  string fileName = this.cellValueRC(row, \"_resDir\") + \"QgTestVersion\\\\_Results\";
   ChildPanelOnCentralModal(\"vision/QualityChecks/QG_Result.pnl\", getCatStr(\"QG_Names\",_qgId), makeDynString(\"$fileName:\" + fileName));
 }
 " 0
@@ -94,14 +94,14 @@ LANG:10001 0
 E E E
 0
 2
-LANG:10000 0 
 LANG:10001 0 
+LANG:10000 0 
 
 1
 "layoutAlignment" "AlignNone"
 2
-LANG:10000 26 Arial,-1,12,5,50,0,0,0,0,0
 LANG:10001 26 Arial,-1,12,5,50,0,0,0,0,0
+LANG:10000 26 Arial,-1,12,5,50,0,0,0,0,0
 0  -2 -2 410 558
 "main()
 {
@@ -110,86 +110,79 @@ LANG:10001 26 Arial,-1,12,5,50,0,0,0,0,0
 }
 " 0
 E 1 0 1 5 0 "time" 16 1 0 "s" 2
-LANG:10000 4 Zeit
 LANG:10001 4 Time
+LANG:10000 4 Zeit
 E
 2
-LANG:10000 0 
 LANG:10001 0 
+LANG:10000 0 
 
 160 "score" 4 1 0 "s" 2
-LANG:10000 5 Score
 LANG:10001 5 Score
+LANG:10000 5 Score
 E
 2
-LANG:10000 0 
 LANG:10001 0 
+LANG:10000 0 
 
 50 "totalPoints" 8 1 0 "s" 2
-LANG:10000 6 Punkte
 LANG:10001 6 Points
+LANG:10000 6 Punkte
 E
 2
-LANG:10000 0 
 LANG:10001 0 
+LANG:10000 0 
 
 60 "errorPoints" 8 1 0 "s" 2
-LANG:10000 6 Fehler
 LANG:10001 6 Errors
+LANG:10000 6 Fehler
 E
 2
-LANG:10000 0 
 LANG:10001 0 
+LANG:10000 0 
 
 60 "_resDir" 21 0 0 "s" 2
-LANG:10000 7 _resDir
 LANG:10001 7 _resDir
+LANG:10000 7 _resDir
 E
 2
-LANG:10000 0 
 LANG:10001 0 
+LANG:10000 0 
 
 200 
 21 21 10 0
 2
-LANG:10000 26 Arial,-1,12,5,50,0,0,0,0,0
 LANG:10001 26 Arial,-1,12,5,50,0,0,0,0,0
+LANG:10000 26 Arial,-1,12,5,50,0,0,0,0,0
 0 0 1 1 1 7
 1 0
 0
 LAYER, 1 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 0
 LAYER, 2 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 0
 LAYER, 3 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 0
 LAYER, 4 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 0
 LAYER, 5 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 0
 LAYER, 6 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 0
 LAYER, 7 
-2
-LANG:10000 0 
+1
 LANG:10001 0 
 0
 4 0 "LAYOUT_GROUP1" -1


### PR DESCRIPTION
Please see issue #71. closes #71 
It seems in pre-release version 1.0.2 the path to where the reports where outputed was changed, however the panel for reading them was not. This bugfix resolves that by updating the QG_History.pnl to include the new path.

Before bug:
![Bugfix_71_Before](https://github.com/siemens/CtrlppCheck/assets/147402639/c7df8d0d-4730-470f-896d-71cf92119b05)

After bug:
![Bugfix_71_After](https://github.com/siemens/CtrlppCheck/assets/147402639/6b4080cd-7a16-48a2-9b8a-c190ed47f877)

@mPokornyETM