### PR TITLE
Open help to quality gates

### DIFF
--- a/WinCCOA_QualityChecks/scripts/libs/gedi/qualityCheck_ext.ctl
+++ b/WinCCOA_QualityChecks/scripts/libs/gedi/qualityCheck_ext.ctl
@@ -167,10 +167,7 @@ void tool_QualityGates_OpenResult()
 
 void open_Docu()
 {
-  if (getLocale(getActiveLang()) == "de_AT.iso88591" || getLocale(getActiveLang()) == "de_AT.utf8")
-    openUrl("https://www.winccoa.com/documentation/WinCCOA/3.18/en_US/index.html");
-  else
-    openUrl("https://www.winccoa.com/documentation/WinCCOA/3.18/en_US/index.html");
+  openUrl("https://github.com/siemens/CtrlppCheck/blob/main/docs/user.md");
 }
 
 void tool_QualityGates_BuildDocu()

--- a/WinCCOA_QualityChecks/scripts/libs/gedi/qualityCheck_ext.ctl
+++ b/WinCCOA_QualityChecks/scripts/libs/gedi/qualityCheck_ext.ctl
@@ -167,7 +167,7 @@ void tool_QualityGates_OpenResult()
 
 void open_Docu()
 {
-  openUrl("https://github.com/siemens/CtrlppCheck/blob/main/docs/user.md");
+  openUrl("https://github.com/siemens/CtrlppCheck/blob/main/README.md");
 }
 
 void tool_QualityGates_BuildDocu()


### PR DESCRIPTION
# Request for a change on public repository on [CtrlppCheck](https://github.com/siemens/CtrlppCheck)

fix #77

Gedi -> Quality Checks -> Open Online Help
shall open help to quality gates (means this repository)

## Technical information


### Testing done

N/N

### Proposed upgrade guidelines

N/A

### Localizations

N/N

### Submitter checklist

- [x] The Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [ ] ~~There is automated testing or an explanation that explains why this change has no tests.~~
- [ ] ~~For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- [ ] ~~Any localizations are transferred to /msg/ files.~~
- [x] Automated tests has been executed and valid

