### PR TITLE
Cannot open reports in WinCC OA script-editor

### DIFF
--- a/WinCCOA_QualityChecks/scripts/libs/classes/QualityGates/QgResultPublisher.ctl
+++ b/WinCCOA_QualityChecks/scripts/libs/classes/QualityGates/QgResultPublisher.ctl
@@ -133,7 +133,7 @@ class QgResultPublisher
   //------------------------------------------------------------------------------
   protected int _publishFull(const QgAddOnResultsDir &resDir)
   {
-    if (Qg::isRunningOnJenkins() || true)
+    if (Qg::isRunningOnJenkins())
       return _publishFullOnJenkins(resDir);
     else
       return _publishFullLocale(resDir);


### PR DESCRIPTION
# Request for a change on public repository on [CtrlppCheck](https://github.com/siemens/CtrlppCheck)

## Basic information

fix #68 
fix #71 
close #82

Automatic tests works as expected and report panels works again

![image](https://github.com/siemens/CtrlppCheck/assets/89339813/1a6ea403-ffea-4af1-b793-16720485fe66)

**note** all the deprecated Jenkins things here in the repo shall be removed. I working still on that parallel. But to fix this issue ASAP I will propose to merge only this changes now. Thx

## Technical information


### Testing done

![image](https://github.com/siemens/CtrlppCheck/assets/89339813/4ea083c4-5584-4923-8be2-c5107afe0a76)

![image](https://github.com/siemens/CtrlppCheck/assets/89339813/a6007697-ea89-46e6-96f5-8be516755b2f)


### Proposed upgrade guidelines

N/A

### Localizations

N/N
